### PR TITLE
Flush cache when link updates

### DIFF
--- a/api/controllers/link-controller.ts
+++ b/api/controllers/link-controller.ts
@@ -165,9 +165,22 @@ export const updateLink = async (
       {
         linkId: linkId,
       },
-      query
+      query,
+      {
+        projection: {
+          _id: 0,
+          shortCode: 1,
+          analyticsCode: 1,
+          clicks: 1,
+          creatorIpAddress: 1,
+          longUrl: 1,
+          timestamp: 1,
+        },
+      }
     );
 
   if (!result.value) throw 404;
-  return result;
+
+  CacheService.getInstance().del(result.value.shortCode);
+  return result.value;
 };

--- a/api/routes/link-routes.ts
+++ b/api/routes/link-routes.ts
@@ -145,8 +145,12 @@ router.put(
     }
 
     try {
-      await updateLink(req.body.linkId, req.body.longUrl, req.body.enabled);
-      return res.status(200).json({ success: true });
+      const result = await updateLink(
+        req.body.linkId,
+        req.body.longUrl,
+        req.body.enabled
+      );
+      return res.status(200).json(result);
     } catch (error) {
       res.status(error).send();
     }


### PR DESCRIPTION
Signed-off-by: Ishan Chhabra <ishan.chhabra@hotmail.com>

# Description

This fixes the code to flush the cache when link updates, ensuring instantaneous updates.

Fixes #15 
Closes #15 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested the API results thoroughly using Postman

## Changes

1. `updateLink` now sends back the modified link document in response
2. Cache gets flushed when the link is updated

## Flags

- N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
