### PR TITLE
fix(shortlink): prefix https to shortlink

### DIFF
--- a/client/src/homePage/FormStructure.svelte
+++ b/client/src/homePage/FormStructure.svelte
@@ -23,7 +23,7 @@
   function copyExec() {
     var $temp = window.$("<input>");
     window.$("body").append($temp);
-    $temp.val(window.$("#shrink").text()).select();
+    $temp.val("https://" + window.$("#shrink").text()).select();
     document.execCommand("copy");
     $temp.remove();
   }


### PR DESCRIPTION
# Description

During the execution of the `copy` command, the value of the element with id `shrink` is prefixed with `https://` so that whenever shortlinks are copied, the proper protocol stays in the place. 

Fixes #114 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The following command has been tested out locally in the browser.
```bash
$temp.val("https://" + window.$("#shrink").text()).select();
```

**Test Configuration**:

- Browser version: Mozilla Forefox Developer Edition 79.0b8 (64-bit)

## Changes

- N/A

## Flags

- N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
