### PR TITLE
🐛 fix: Fixing broken QR codes and URLs shown in /analytics

### DIFF
--- a/client/src/analyticsPage/HeroTag.svelte
+++ b/client/src/analyticsPage/HeroTag.svelte
@@ -53,7 +53,7 @@
   </div>
   <div class="col-md-6">
     <div class="hero-div">
-      <h5 class="hero-url">{API.KZILLA_URL}{analyticsId}</h5>
+      <h5 class="hero-url">{API.KZILLA_URL}analytics/{analyticsId}</h5>
     </div>
 
   </div>

--- a/client/src/myLinksPage/Qrjs.svelte
+++ b/client/src/myLinksPage/Qrjs.svelte
@@ -1,41 +1,36 @@
 <script>
-  import { onMount } from 'svelte';
-	
+	import { onMount } from 'svelte';
+
 	export let codeValue;
-	export let squareSize; 
-	
-  let qrcode;
-			
+	export let squareSize;
+
+	let qrcode;
+
 	onMount(() => {
-
 		let script = document.createElement('script');
-    script.src = "https://cdn.rawgit.com/davidshimjs/qrcodejs/gh-pages/qrcode.min.js";
-    document.head.append(script);
-	
-		script.onload = function() {
+		script.src = 'https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js';
+		document.head.append(script);
 
+		script.onload = function () {
 			qrcode = new QRCode(codeValue, {
 				text: codeValue,
-		  	width: squareSize,
-        height: squareSize,
-        colorDark : "#000000",
-        colorLight : "#ffffff",
-        correctLevel : QRCode.CorrectLevel.H
-			});		
-			
-    };
-  });
-  
+				width: squareSize,
+				height: squareSize,
+				colorDark: '#000000',
+				colorLight: '#ffffff',
+				correctLevel: QRCode.CorrectLevel.H
+			});
+		};
+	});
 </script>
 
+<div class="qrcode" id={codeValue} />
+
 <style>
-  .qrcode {
-    width:250px;
-    height:300px;
-    margin-top:15px;
-    margin: auto;
-  }
+	.qrcode {
+		width: 250px;
+		height: 300px;
+		margin-top: 15px;
+		margin: auto;
+	}
 </style>
-
-<div class="qrcode" id="{codeValue}"></div>
-


### PR DESCRIPTION
# Description

## First change

Rawgit, the CDN that was initially used by this service had recently shut down its services and therefore, the shrinker ceased to generate QR codes due to undefined functions

- [Rawgit's sunset notice](https://rawgit.com)

This PR replaces Rawgit's CDN with [cdnjs](https://cdnjs.com)

- [cdnjs' page on qrcodejs](https://cdnjs.com/libraries/qrcodejs)
- [Similar issue on the repo's page](https://github.com/davidshimjs/qrcodejs/issues/200)

![image](https://user-images.githubusercontent.com/84540554/194441789-baf56bce-cbab-46f0-b202-c0c5a9a72c1e.png)

![image](https://user-images.githubusercontent.com/84540554/194441821-8a46ec69-4622-4212-afa2-c06c2fcb4d7f.png)

## Second change

The URL shown in the `HeroTag` component of `/analytics` is invalid as it's missing the `/analytics/` sub directory. 
It only shows `kzilla.xyz/analyticsID` which isn't a valid URL because the analytics ID is, for some reason, different from the `shortCode` but that is beside the point of this PR 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes

- Updated CDN for QRcode generator
- Updated formatting for `Qrjs.svelte`
- Fixed broken URL shown in `/analytics`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
