### PR TITLE
Updated Link Schema

### DIFF
--- a/api/models/joi-schemas.ts
+++ b/api/models/joi-schemas.ts
@@ -11,10 +11,8 @@ export const createLinkSchema = Joi.object({
     .required()
     .trim(),
   customCode: Joi.string()
-    .regex(
-      /^(?=.*[A-Za-z])[^-_][-\w]{3,25}$/
-    )
-    .trim()
+    .regex(/^(?=.*[A-Za-z])[^-_][-\w]{3,25}$/)
+    .trim(),
 });
 
 /**
@@ -33,7 +31,7 @@ export const updateLinkSchema = Joi.object({
     .regex(/^[A-Za-z]{12}$/)
     .required(),
   longUrl: Joi.string().regex(
-    /^(?:(http|https|ftp)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/
+    /^(?:(?!.*kzilla\.xyz).*?(http|https|ftp):\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-\._~:/?#[\]@!\$&'()*+,;=]+$/
   ),
   enabled: Joi.bool(),
 }).xor("longUrl", "enabled");

--- a/api/models/joi-schemas.ts
+++ b/api/models/joi-schemas.ts
@@ -6,7 +6,7 @@ import Joi from "@hapi/joi";
 export const createLinkSchema = Joi.object({
   longUrl: Joi.string()
     .regex(
-      /^(?:(http|https|ftp)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]%@!\$&'\(\)\*\+,;=.]+$/
+      /^(?:(?!.*kzilla\.xyz).*?(http|https|ftp):\/\/)?[\w.-]+(?:\.[\w.-]+)+[\w\-\._~:/?#[\]@!\$&'()*+,;=]+$/
     )
     .required()
     .trim(),


### PR DESCRIPTION
# Description
I have updated the regex such that it does not allow links of `kzilla.xyz` domain. ( Fixes #217 )

## Before: 
  - We are able to go to the Update Links and edit the URL (short/long) to itself which leads to an infinite redirect in specific devices or redirects until the firewall detects it.
 - Apart from this if people used the API of this people were able to create shortened links for `kzilla.xyz` links using API, which should not be allowed.

### Before Example:
 - During Creation: https://kzilla.xyz/helloworld - ❌
 - During Updating: https://kzilla.xyz/helloworld - ✅
 - Using API creation/Updating: - https://kzilla.xyz/helloworld - ✅
 
 ## After:
   - After Updating the regex we no longer allowed making `kzilla.xyz` links using API as well as we stop users from updating their links later on to `Kzilla.xyz` link.
 
### After Example
 - During Creation: https://kzilla.xyz/helloworld - ❌
 - During Updating: https://kzilla.xyz/helloworld - ❌
 - Using API creation/Updating: - https://kzilla.xyz/helloworld - ❌
 
 --- 
 ✅ - Allowed/Permitted
 ❌ - Not Allowed/Not Permitted