### PR TITLE
fix: 404 page in <4 letter shortcode

### DIFF
--- a/api/controllers/link-controller.ts
+++ b/api/controllers/link-controller.ts
@@ -5,6 +5,8 @@ import { DatabaseService } from "../services/database-service";
 import { generateRandomCode } from "../utils/link-helpers";
 import * as metaget from "metaget";
 import { SERVER_ERROR, CUSTOM_CODE_ALREADY_EXISTS } from "../errors";
+import { generatePageNotFound } from "../utils/ejs-templates";
+import { Response, Request } from "express";
 
 /**
  * Handles creation of links
@@ -38,7 +40,7 @@ export const createLink = async (
     if (!customCode) return createLink(longUrl, ipAddress);
     result = await database
       .find(
-        { shortCode : shortCode }
+        { shortCode: shortCode }
       )
       .toArray();
 
@@ -100,10 +102,10 @@ export const fetchLink = async (shortCode: string) => {
   }
 
   try {
-    if(result.longUrl.startsWith("https://"))
-    result.meta = await metaget.fetch(result.longUrl);
+    if (result.longUrl.startsWith("https://"))
+      result.meta = await metaget.fetch(result.longUrl);
     else
-    result.meta = await metaget.fetch("https://" + result.longUrl);
+      result.meta = await metaget.fetch("https://" + result.longUrl);
   } catch (e) {
     result.meta = {};
   }
@@ -205,3 +207,8 @@ export const updateLink = async (
   CacheService.getInstance().del(result.value.shortCode);
   return result.value;
 };
+
+export const catchAllRoutes = async (req: Request, res: Response) => {
+  const html = await generatePageNotFound();
+  res.status(404).send(html as string);
+}

--- a/server.ts
+++ b/server.ts
@@ -6,6 +6,7 @@ import cookieParser from "cookie-parser";
 import cors from "cors";
 import { config } from "dotenv";
 import { mw } from "request-ip";
+import { catchAllRoutes } from "./api/controllers/link-controller";
 import { Constants, APIEndpoints } from "./api/constants";
 import linksRoute, { fetchLink } from "./api/routes/link-routes";
 import analyticsRoutes from "./api/routes/analytics-routes";
@@ -131,12 +132,17 @@ class Server {
       "/me",
       express.static(path.join(__dirname, "..", "client", "public"))
     );
+
+    this.app.all(
+      "*", catchAllRoutes
+
+    )
   }
 
   /**
    * Mounts secured routes into the Express instance
    */
-  private mountSecuredRoutes() {}
+  private mountSecuredRoutes() { }
 
   /**
    * Establish a connection with the database


### PR DESCRIPTION
# Description

When trying to access a link that does not exist, a 404 Page must be displayed (Link Broken), this happens only if the shortcode is less than 5 or more than 5. Fixed it using `app.all` method by catching all other routes

Fixes # (issue)
#207 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Put two letters after kzilla.xyz. Ex: `kzilla.xyz/gg`
![image](https://github.com/srm-kzilla/kzilla.xyz/assets/69302420/e702aa2a-8fd9-4282-9650-babe5e8061b0)

## Changes

- N/A

## Flags

- N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
